### PR TITLE
Fix override of timezone in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update -qq \
 # Set up the default timezone for PHP.
 # `php-nginx` sets timezone for FPM configuration, but not CLI.
 # This ensures PHP CLI inside container have timezone set too.
-RUN echo "date.timezone = UTC" >> /etc/php/7.0/cli/conf.d/docker.ini
+RUN echo "date.timezone = UTC" >> /etc/php/7.1/cli/conf.d/docker.ini
 
 # Copy the entire current directory into container's `/app`.
 COPY . /app/


### PR DESCRIPTION
When building container, command `RUN echo "date.timezone = UTC" >> /etc/php/7.0/cli/conf.d/docker.ini` fails because the directory `7.0` does not exist (also reported in issue https://github.com/everzet/sylius-docker/issues/3).